### PR TITLE
Add file extension to wordsSorted import in madLibPhrases.js file

### DIFF
--- a/madLibPhrases.js
+++ b/madLibPhrases.js
@@ -2,7 +2,7 @@
 // noun, language, person, adjective, verb, gerund, phrase, abbreviation
 // combine nouns and languages for now
 const sample = require('lodash/sample')
-const words = require('./wordsSorted')
+const words = require('./wordsSorted.json')
 
 function noun() {
   return sample(words.noun)


### PR DESCRIPTION
Importing .json files without extension, causes errors when using with for example TypeScript, and is not a good practice. 